### PR TITLE
Set cwd to its initial path when opening file in current buffer

### DIFF
--- a/autoload/readdir.vim
+++ b/autoload/readdir.vim
@@ -2,17 +2,17 @@
 " Licence:     The MIT License (MIT)
 " Commit:      $Format:%H$
 " {{{ Copyright (c) 2015 Aristotle Pagaltzis <pagaltzis@gmx.de>
-" 
+"
 " Permission is hereby granted, free of charge, to any person obtaining a copy
 " of this software and associated documentation files (the "Software"), to deal
 " in the Software without restriction, including without limitation the rights
 " to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 " copies of the Software, and to permit persons to whom the Software is
 " furnished to do so, subject to the following conditions:
-" 
+"
 " The above copyright notice and this permission notice shall be included in
 " all copies or substantial portions of the Software.
-" 
+"
 " THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 " IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 " FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -63,13 +63,13 @@ function readdir#Show(path, focus)
 	call cursor(line ? line : 1, 1)
 
 	call extend( b:readdir, { 'cwd': a:path, 'content': content } )
+	silent lchdir `=b:readdir.initialPath`
 endfunction
 
 function readdir#Open(path)
 	if isdirectory(a:path) | return a:path == b:readdir.cwd || readdir#Show( a:path, b:readdir.cwd ) | endif
 
 	if s:set_bufname(a:path)
-		silent lchdir `=b:readdir.initialPath`
 		unlet b:readdir
 		set modifiable< buftype< filetype< noswapfile< wrap<
 		mapclear <buffer>

--- a/autoload/readdir.vim
+++ b/autoload/readdir.vim
@@ -69,6 +69,7 @@ function readdir#Open(path)
 	if isdirectory(a:path) | return a:path == b:readdir.cwd || readdir#Show( a:path, b:readdir.cwd ) | endif
 
 	if s:set_bufname(a:path)
+		silent lchdir `=b:readdir.initialPath`
 		unlet b:readdir
 		set modifiable< buftype< filetype< noswapfile< wrap<
 		mapclear <buffer>

--- a/ftplugin/readdir.vim
+++ b/ftplugin/readdir.vim
@@ -2,17 +2,17 @@
 " Licence:     The MIT License (MIT)
 " Commit:      $Format:%H$
 " {{{ Copyright (c) 2015 Aristotle Pagaltzis <pagaltzis@gmx.de>
-" 
+"
 " Permission is hereby granted, free of charge, to any person obtaining a copy
 " of this software and associated documentation files (the "Software"), to deal
 " in the Software without restriction, including without limitation the rights
 " to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 " copies of the Software, and to permit persons to whom the Software is
 " furnished to do so, subject to the following conditions:
-" 
+"
 " The above copyright notice and this permission notice shall be included in
 " all copies or substantial portions of the Software.
-" 
+"
 " THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 " IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 " FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,8 +23,8 @@
 " }}}
 
 if v:version < 700
-	echoerr printf('Vim 7 is required for readdir (this is only %d.%d)',v:version/100,v:version%100)
-	finish
+  echoerr printf('Vim 7 is required for readdir (this is only %d.%d)',v:version/100,v:version%100)
+  finish
 endif
 
 if exists('b:readdir') || ! isdirectory(expand('%')) | finish | endif
@@ -33,7 +33,7 @@ let id = range(1,bufnr('$'))
 let taken = map(copy(id),'getbufvar(v:val,"readdir_id")')
 let b:readdir = { 'id': filter(id,'index(taken,v:val) < 0')[0] }
 let b:readdir.hidden = get(g:, 'readdir_hidden', 0)
-let b:readdir.initialPath = simplify( expand('%:p').'.' )
+let b:readdir.initialPath = getcwd()
 
 setlocal buftype=nofile noswapfile undolevels=-1 nomodifiable nowrap
 call readdir#Show( b:readdir.initialPath, '' )

--- a/ftplugin/readdir.vim
+++ b/ftplugin/readdir.vim
@@ -33,9 +33,10 @@ let id = range(1,bufnr('$'))
 let taken = map(copy(id),'getbufvar(v:val,"readdir_id")')
 let b:readdir = { 'id': filter(id,'index(taken,v:val) < 0')[0] }
 let b:readdir.hidden = get(g:, 'readdir_hidden', 0)
+let b:readdir.initialPath = simplify( expand('%:p').'.' )
 
 setlocal buftype=nofile noswapfile undolevels=-1 nomodifiable nowrap
-call readdir#Show( simplify( expand('%:p').'.' ), '' )
+call readdir#Show( b:readdir.initialPath, '' )
 
 autocmd ReadDir BufEnter <buffer> silent lchdir `=b:readdir.cwd`
 nnoremap <buffer> <silent> <CR> :call readdir#Open( readdir#Selected() )<CR>

--- a/ftplugin/readdir.vim
+++ b/ftplugin/readdir.vim
@@ -36,7 +36,7 @@ let b:readdir.hidden = get(g:, 'readdir_hidden', 0)
 let b:readdir.initialPath = getcwd()
 
 setlocal buftype=nofile noswapfile undolevels=-1 nomodifiable nowrap
-call readdir#Show( b:readdir.initialPath, '' )
+call readdir#Show(simplify(expand('%:p').'.'), '' )
 
 autocmd ReadDir BufEnter <buffer> silent lchdir `=b:readdir.cwd`
 nnoremap <buffer> <silent> <CR> :call readdir#Open( readdir#Selected() )<CR>


### PR DESCRIPTION
Hi,

I really enjoy your module along with the vim-buftabline, but one thing that was very annoying for me personally is that it does not set its cwd back using `lchdir` to where it came from. Issue #2 mentioned this as well. Unfortunately I haven't experienced a fix yet and thus you receive this merge request containing the fix.

### The problem itself

I am using vim-fzf as my fuzzy file finder and it’s based on the directory I have started opening vim (it uses the `pwd` command for this). If I end up in a directory opening a file using vim-readdir, then when I open fzf it starts searching from the current directory, which is not what I expected.

### Expected behavior

If I enter vim using `vim ~/dotfiles` and I go 3 directories deeper and then open a file, I expect the result of `:pwd` to be still `~/dotfiles` and not `~/dotfiles/dirA/dirB/dirC`.

### The solution

What I did in the code is using the initial path you pass initially to `readdir#Show()` and put it in a variable in the `b:readdir` and then when I open a file I call `lchdir` with the initial path I opened the buffer with, just before doing `unlet b:readdir`.

I really prefer this solution personally when it comes to user experience. I hope you are willing to merge this pull request, else I have to use my own forked version. 